### PR TITLE
Add option to allow mongorestore to build indexes in the foreground

### DIFF
--- a/mongorestore/metadata.go
+++ b/mongorestore/metadata.go
@@ -169,6 +169,17 @@ func (restore *MongoRestore) CreateIndexes(dbName string, collectionName string,
 		}
 		indexNames = append(indexNames, index.Options["name"].(string))
 
+		// default is to build indexes in the background
+		// unless we specifically want to follow the dump metadata
+		if !restore.OutputOptions.AllowForegroundIndexBuild {
+			index.Options["background"] = true
+		}
+
+		// specifically force all indexes to be built in foreground
+		if restore.OutputOptions.ForceForegroundIndexBuild {
+			delete(index.Options, "background")
+		}
+
 		// remove the index version, forcing an update,
 		// unless we specifically want to keep it
 		if !restore.OutputOptions.KeepIndexVersion {

--- a/mongorestore/mongorestore.go
+++ b/mongorestore/mongorestore.go
@@ -288,6 +288,11 @@ func (restore *MongoRestore) ParseAndValidateOptions() error {
 	if err != nil {
 		return fmt.Errorf("invalid renames: %v", err)
 	}
+	
+	if restore.OutputOptions.AllowForegroundIndexBuild && restore.OutputOptions.ForceForegroundIndexBuild {
+		return fmt.Errorf(
+			"--forceForegroundIndexBuild is not allowed when --allowForegroundIndexBuild is specified")
+	}
 
 	if restore.OutputOptions.NumInsertionWorkers < 0 {
 		return fmt.Errorf(

--- a/mongorestore/options.go
+++ b/mongorestore/options.go
@@ -67,23 +67,25 @@ func (*InputOptions) Name() string {
 
 // OutputOptions command line argument long names
 const (
-	DropOption                     = "--drop"
-	DryRunOption                   = "--dryRun"
-	WriteConcernOption             = "--writeConcern"
-	NoIndexRestoreOption           = "--noIndexRestore"
-	ConvertLegacyIndexesOption     = "--convertLegacyIndexes"
-	NoOptionsRestoreOption         = "--noOptionsRestore"
-	KeepIndexVersionOption         = "--keepIndexVersion"
-	MaintainInsertionOrderOption   = "--maintainInsertionOrder"
-	NumParallelCollectionsOption   = "--numParallelCollections"
-	NumInsertionWorkersOption      = "--numInsertionWorkersPerCollection"
-	StopOnErrorOption              = "--stopOnError"
-	BypassDocumentValidationOption = "--bypassDocumentValidation"
-	PreserveUUIDOption             = "--preserveUUID"
-	TempUsersCollOption            = "--tempUsersColl"
-	TempRolesCollOption            = "--tempRolesColl"
-	BulkBufferSizeOption           = "--batchSize"
-	FixDottedHashedIndexesOption   = "--fixDottedHashIndex"
+	DropOption                      = "--drop"
+	DryRunOption                    = "--dryRun"
+	WriteConcernOption              = "--writeConcern"
+	NoIndexRestoreOption            = "--noIndexRestore"
+	AllowForegroundIndexBuildOption = "--allowForegroundIndexBuild"
+	ForceForegroundIndexBuildOption = "--forceForegroundIndexBuild"
+	ConvertLegacyIndexesOption      = "--convertLegacyIndexes"
+	NoOptionsRestoreOption          = "--noOptionsRestore"
+	KeepIndexVersionOption          = "--keepIndexVersion"
+	MaintainInsertionOrderOption    = "--maintainInsertionOrder"
+	NumParallelCollectionsOption    = "--numParallelCollections"
+	NumInsertionWorkersOption       = "--numInsertionWorkersPerCollection"
+	StopOnErrorOption               = "--stopOnError"
+	BypassDocumentValidationOption  = "--bypassDocumentValidation"
+	PreserveUUIDOption              = "--preserveUUID"
+	TempUsersCollOption             = "--tempUsersColl"
+	TempRolesCollOption             = "--tempRolesColl"
+	BulkBufferSizeOption            = "--batchSize"
+	FixDottedHashedIndexesOption    = "--fixDottedHashIndex"
 )
 
 // OutputOptions defines the set of options for restoring dump data.
@@ -92,21 +94,23 @@ type OutputOptions struct {
 	DryRun bool `long:"dryRun" description:"view summary without importing anything. recommended with verbosity"`
 
 	// By default mongorestore uses a write concern of 'majority'.
-	WriteConcern             string `long:"writeConcern" value-name:"<write-concern>" default-mask:"-" description:"write concern options e.g. --writeConcern majority, --writeConcern '{w: 3, wtimeout: 500, fsync: true, j: true}'"`
-	NoIndexRestore           bool   `long:"noIndexRestore" description:"don't restore indexes"`
-	ConvertLegacyIndexes     bool   `long:"convertLegacyIndexes" description:"Removes invalid index options and rewrites legacy option values (e.g. true becomes 1)."`
-	NoOptionsRestore         bool   `long:"noOptionsRestore" description:"don't restore collection options"`
-	KeepIndexVersion         bool   `long:"keepIndexVersion" description:"don't update index version"`
-	MaintainInsertionOrder   bool   `long:"maintainInsertionOrder" description:"restore the documents in the order of their appearance in the input source. By default the insertions will be performed in an arbitrary order. Setting this flag also enables the behavior of --stopOnError and restricts NumInsertionWorkersPerCollection to 1."`
-	NumParallelCollections   int    `long:"numParallelCollections" short:"j" description:"number of collections to restore in parallel" default:"4" default-mask:"-"`
-	NumInsertionWorkers      int    `long:"numInsertionWorkersPerCollection" description:"number of insert operations to run concurrently per collection" default:"1" default-mask:"-"`
-	StopOnError              bool   `long:"stopOnError" description:"halt after encountering any error during insertion. By default, mongorestore will attempt to continue through document validation and DuplicateKey errors, but with this option enabled, the tool will stop instead. A small number of documents may be inserted after encountering an error even with this option enabled; use --maintainInsertionOrder to halt immediately after an error"`
-	BypassDocumentValidation bool   `long:"bypassDocumentValidation" description:"bypass document validation"`
-	PreserveUUID             bool   `long:"preserveUUID" description:"preserve original collection UUIDs (off by default, requires drop)"`
-	TempUsersColl            string `long:"tempUsersColl" default:"tempusers" hidden:"true"`
-	TempRolesColl            string `long:"tempRolesColl" default:"temproles" hidden:"true"`
-	BulkBufferSize           int    `long:"batchSize" default:"1000" hidden:"true"`
-	FixDottedHashedIndexes   bool   `long:"fixDottedHashIndex" description:"when enabled, all the hashed indexes on dotted fields will be created as single field ascending indexes on the destination"`
+	WriteConcern              string `long:"writeConcern" value-name:"<write-concern>" default-mask:"-" description:"write concern options e.g. --writeConcern majority, --writeConcern '{w: 3, wtimeout: 500, fsync: true, j: true}'"`
+	NoIndexRestore            bool   `long:"noIndexRestore" description:"don't restore indexes"`
+	AllowForegroundIndexBuild bool   `long:"allowForegroundIndexBuild" description:"only build indexes in foreground if specified in metadata"`
+	ForceForegroundIndexBuild bool   `long:"forceForegroundIndexBuild" description:"force build all indexes in foreground"`
+	ConvertLegacyIndexes      bool   `long:"convertLegacyIndexes" description:"Removes invalid index options and rewrites legacy option values (e.g. true becomes 1)."`
+	NoOptionsRestore          bool   `long:"noOptionsRestore" description:"don't restore collection options"`
+	KeepIndexVersion          bool   `long:"keepIndexVersion" description:"don't update index version"`
+	MaintainInsertionOrder    bool   `long:"maintainInsertionOrder" description:"restore the documents in the order of their appearance in the input source. By default the insertions will be performed in an arbitrary order. Setting this flag also enables the behavior of --stopOnError and restricts NumInsertionWorkersPerCollection to 1."`
+	NumParallelCollections    int    `long:"numParallelCollections" short:"j" description:"number of collections to restore in parallel" default:"4" default-mask:"-"`
+	NumInsertionWorkers       int    `long:"numInsertionWorkersPerCollection" description:"number of insert operations to run concurrently per collection" default:"1" default-mask:"-"`
+	StopOnError               bool   `long:"stopOnError" description:"halt after encountering any error during insertion. By default, mongorestore will attempt to continue through document validation and DuplicateKey errors, but with this option enabled, the tool will stop instead. A small number of documents may be inserted after encountering an error even with this option enabled; use --maintainInsertionOrder to halt immediately after an error"`
+	BypassDocumentValidation  bool   `long:"bypassDocumentValidation" description:"bypass document validation"`
+	PreserveUUID              bool   `long:"preserveUUID" description:"preserve original collection UUIDs (off by default, requires drop)"`
+	TempUsersColl             string `long:"tempUsersColl" default:"tempusers" hidden:"true"`
+	TempRolesColl             string `long:"tempRolesColl" default:"temproles" hidden:"true"`
+	BulkBufferSize            int    `long:"batchSize" default:"1000" hidden:"true"`
+	FixDottedHashedIndexes    bool   `long:"fixDottedHashIndex" description:"when enabled, all the hashed indexes on dotted fields will be created as single field ascending indexes on the destination"`
 }
 
 // Name returns a human-readable group name for output options.


### PR DESCRIPTION
The original topic for this PR: https://jira.mongodb.org/browse/TOOLS-936

This PR changes the default behavior of index creation operation:
- now all indexes will be created in the background by default;
- if we provide `AllowForegroundIndexBuild` option - the index creation mode will be selected using index metadata (_background_ option);
- if we provide the `ForceForegroundIndexBuild` option - each index will be created in the foreground.